### PR TITLE
Fix invalid HTML comments in video tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,9 @@
                     muted 
                     playsinline
                     controls
-                    width="640" /* Base width, CSS will make it responsive */
-                    height="360"> /* Base height, helps with aspect ratio before CSS loads */
+                    width="640"
+                    height="360">
+                    <!-- Base width & height. CSS will handle responsiveness -->
                     Your browser does not support the video tag.
                 </video>
             </div>


### PR DESCRIPTION
## Summary
- remove invalid comments from `video` attributes

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_684413d2bfbc8324a6ebb3cb99838f28